### PR TITLE
Fixed random crash after some time

### DIFF
--- a/lib/src/net.dart
+++ b/lib/src/net.dart
@@ -368,7 +368,7 @@ class Connection {
     String responseBuf;
     int responseLen;
 
-    _responseBuffer.addAll(res);
+    _responseBuffer.addAll(List<int>.from(res));
 
     _responseLength = _responseBuffer.length;
 


### PR DESCRIPTION
My API Server opens a connection to RethinkDB, but after about one day, the connection crashes. This change fixed the issue for me.